### PR TITLE
Additional features

### DIFF
--- a/Source/main.cpp
+++ b/Source/main.cpp
@@ -447,14 +447,18 @@ int CALLBACK WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLi
 
 			if (Settings::CheckForUpdates)
 			{
-				printf("Checking for updates...\n");
+				printf("Checking for updates...\n"); // goes to hidden console regardless of QuickStart
 				if (CheckForUpdates()) return 0;
 			}
 
 			if (!Settings::QuickStart)
 			{
-				printf("Minimizing to system tray in 2 seconds...\n");
-				Sleep(2000);
+				if (Settings::MinimizeToTray)
+				{
+					printf("Minimizing to system tray in 2 seconds...\n");
+					Sleep(2000);
+				}
+
 				UI::ToggleConsole();
 			}
 

--- a/Source/settings.cpp
+++ b/Source/settings.cpp
@@ -16,6 +16,7 @@ namespace Settings
 	bool NonBlockingErrors = true;
 	bool SilentErrors = false;
 	bool QuickStart = false;
+	bool MinimizeToTray = true;
 
 	bool Init()
 	{
@@ -28,7 +29,10 @@ namespace Settings
 
 	bool Load()
 	{
-		std::ifstream file("settings");
+		std::string appdata(getenv("localappdata"));
+		std::string path = "\\Roblox\\rbxfpsunlocker.cfg";
+		
+		std::ifstream file(appdata + path);
 		if (!file.is_open()) return false;
 
 		printf("Loading settings from file...\n");
@@ -63,6 +67,8 @@ namespace Settings
 						SilentErrors = std::stoi(value) != 0;
 					else if (key == "QuickStart")
 						QuickStart = std::stoi(value) != 0;
+					else if (key == "MinimizeToTray")
+						MinimizeToTray = std::stoi(value) != 0;
 				}
 				catch (std::exception& e)
 				{
@@ -76,7 +82,10 @@ namespace Settings
 
 	bool Save()
 	{
-		std::ofstream file("settings");
+		std::string appdata(getenv("localappdata"));
+		std::string path = "\\Roblox\\rbxfpsunlocker.cfg";
+
+		std::ofstream file(appdata + path);
 		if (!file.is_open()) return false;
 
 		printf("Saving settings to file...\n");
@@ -89,6 +98,7 @@ namespace Settings
 		file << "NonBlockingErrors=" << std::to_string(NonBlockingErrors) << std::endl;
 		file << "SilentErrors=" << std::to_string(SilentErrors) << std::endl;
 		file << "QuickStart=" << std::to_string(QuickStart) << std::endl;
+		file << "MinimizeToTray=" << std::to_string(MinimizeToTray) << std::endl;
 
 		return true;
 	}

--- a/Source/settings.h
+++ b/Source/settings.h
@@ -11,6 +11,7 @@ namespace Settings
 	extern bool NonBlockingErrors;
 	extern bool SilentErrors;
 	extern bool QuickStart;
+	extern bool MinimizeToTray;
 
 	bool Init();
 	bool Load();

--- a/Source/ui.cpp
+++ b/Source/ui.cpp
@@ -21,6 +21,7 @@
 #define RFU_TRAYMENU_ADV_SE		WM_APP + 11
 #define RFU_TRAYMENU_ADV_QS		WM_APP + 12
 #define RFU_TRAYMENU_CLIENT		WM_APP + 13
+#define RFU_TRAYMENU_MINITRAY	WM_APP + 14
 
 #define RFU_FCS_FIRST			(WM_APP + 20)
 #define RFU_FCS_NONE			RFU_FCS_FIRST + 0
@@ -29,7 +30,8 @@
 #define RFU_FCS_75				RFU_FCS_FIRST + 3
 #define RFU_FCS_120				RFU_FCS_FIRST + 4
 #define RFU_FCS_144				RFU_FCS_FIRST + 5
-#define RFU_FCS_240				RFU_FCS_FIRST + 6
+#define RFU_FCS_200             RFU_FCS_FIRST + 6
+#define RFU_FCS_240				RFU_FCS_FIRST + 7
 #define RFU_FCS_LAST			(RFU_FCS_240)
 
 HWND UI::Window = NULL;
@@ -60,6 +62,7 @@ LRESULT CALLBACK WindowProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
 
 			AppendMenu(popup, MF_STRING | (Settings::UnlockClient ? MF_CHECKED : 0), RFU_TRAYMENU_CLIENT, "Unlock Roblox Player");
 			AppendMenu(popup, MF_STRING | (Settings::UnlockStudio ? MF_CHECKED : 0), RFU_TRAYMENU_STUDIO, "Unlock Roblox Studio");
+			AppendMenu(popup, MF_STRING | (Settings::MinimizeToTray ? MF_CHECKED : 0), RFU_TRAYMENU_MINITRAY, "Minimize to Tray");
 			AppendMenu(popup, MF_STRING | (Settings::CheckForUpdates ? MF_CHECKED : 0), RFU_TRAYMENU_CFU, "Check for Updates");
 
 			HMENU submenu = CreatePopupMenu();
@@ -69,6 +72,7 @@ LRESULT CALLBACK WindowProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
 			AppendMenu(submenu, MF_STRING, RFU_FCS_75, "75");
 			AppendMenu(submenu, MF_STRING, RFU_FCS_120, "120");
 			AppendMenu(submenu, MF_STRING, RFU_FCS_144, "144");
+			AppendMenu(submenu, MF_STRING, RFU_FCS_200, "200");
 			AppendMenu(submenu, MF_STRING, RFU_FCS_240, "240");
 			CheckMenuRadioItem(submenu, RFU_FCS_FIRST, RFU_FCS_LAST, RFU_FCS_FIRST + Settings::FPSCapSelection, MF_BYCOMMAND);
 			AppendMenu(popup, MF_POPUP, (UINT_PTR)submenu, "FPS Cap");
@@ -144,11 +148,16 @@ LRESULT CALLBACK WindowProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
 					CheckMenuItem(popup, RFU_TRAYMENU_ADV_QS, Settings::QuickStart ? MF_CHECKED : MF_UNCHECKED);
 					break;
 
+				case RFU_TRAYMENU_MINITRAY:
+					Settings::MinimizeToTray = !Settings::MinimizeToTray;
+					CheckMenuItem(popup, RFU_TRAYMENU_MINITRAY, Settings::MinimizeToTray ? MF_CHECKED : MF_UNCHECKED);
+					break;
+
 				default:
 					if (result >= RFU_FCS_FIRST
 						&& result <= RFU_FCS_LAST)
 					{
-						static double fcs_map[] = { 0.0, 30.0, 60.0, 75.0, 120.0, 144.0, 240.0 };
+						static double fcs_map[] = { 0.0, 30.0, 60.0, 75.0, 120.0, 144.0, 200.0, 240.0 };
 						Settings::FPSCapSelection = result - RFU_FCS_FIRST;
 						Settings::FPSCap = fcs_map[Settings::FPSCapSelection];
 					}
@@ -239,15 +248,18 @@ int UI::Start(HINSTANCE instance, LPTHREAD_START_ROUTINE watchthread)
 	if (!UI::Window)
 		return 0;
 
-	NotifyIconData.cbSize = sizeof(NotifyIconData);
-	NotifyIconData.hWnd = UI::Window;
-	NotifyIconData.uID = IDI_ICON1;
-	NotifyIconData.uFlags = NIF_MESSAGE | NIF_ICON | NIF_TIP;
-	NotifyIconData.uCallbackMessage = RFU_TRAYICON;
-	NotifyIconData.hIcon = LoadIcon(instance, MAKEINTRESOURCE(IDI_ICON1));
-	strcpy_s(NotifyIconData.szTip, "Roblox FPS Unlocker");
+	if (Settings::MinimizeToTray)
+	{
+		NotifyIconData.cbSize = sizeof(NotifyIconData);
+		NotifyIconData.hWnd = UI::Window;
+		NotifyIconData.uID = IDI_ICON1;
+		NotifyIconData.uFlags = NIF_MESSAGE | NIF_ICON | NIF_TIP;
+		NotifyIconData.uCallbackMessage = RFU_TRAYICON;
+		NotifyIconData.hIcon = LoadIcon(instance, MAKEINTRESOURCE(IDI_ICON1));
+		strcpy_s(NotifyIconData.szTip, "Roblox FPS Unlocker");
 
-	Shell_NotifyIcon(NIM_ADD, &NotifyIconData);
+		Shell_NotifyIcon(NIM_ADD, &NotifyIconData);
+	}
 
 	WatchThread = CreateThread(NULL, 0, watchthread, NULL, NULL, NULL);
 


### PR DESCRIPTION
- config file in %localappdata%\Roblox\rbxfpsunlocker.cfg so that if the executable is in the startup folder, Windows doesn't try to open the config file (same dir).
- Settings::MinimizeToTray - true by default
- 200 fps cap selection

I haven't tested this that much, so there might be an issue (especially in the Settings::MinimizeToTray implementation.) All seems to be working on my machine though