### PR TITLE
Add github actions workflow to build and release

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
       uses: actions/upload-artifact@v3
       with:
         name: rbxfpsunlocker (${{ matrix.configuration }}, ${{ matrix.platform }})
-        path: ${{ matrix.platform }}\${{ matrix.configuration }}\*
+        path: ${{ matrix.platform == 'x86' && '.' || matrix.platform }}\${{ matrix.configuration }}\*
 
   release:
     needs: build
@@ -40,14 +40,25 @@ jobs:
       - name: Get tag version
         id: get_version
         uses: battila7/get-version-action@v2
-      - uses: actions/download-artifact@v3
+      - name: Download release binary (x64)
+        uses: actions/download-artifact@v3
         with:
           name: rbxfpsunlocker (Release, x64)
-      - name: Zip binary
-        run: zip -9 rbxfpsunlocker-x64.zip rbxfpsunlocker.exe
+          path: x64
+      - name: Download release binary (x86)
+        uses: actions/download-artifact@v3
+        with:
+          name: rbxfpsunlocker (Release, x86)
+          path: x86
+      - name: Zip binaries
+        run: |
+          zip -9 rbxfpsunlocker-x64.zip x64/rbxfpsunlocker.exe
+          zip -9 rbxfpsunlocker-x86.zip x86/rbxfpsunlocker.exe
       - name: Release
         uses: softprops/action-gh-release@v1
         with:
           draft: true
-          files: rbxfpsunlocker-x64.zip
+          files: |
+            rbxfpsunlocker-x64.zip
+            rbxfpsunlocker-x86.zip
           name: Roblox FPS Unlocker ${{ steps.get_version.outputs.version }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,53 @@
+name: ci
+
+on:
+  push:
+    tags:
+      - 'v*'
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        configuration: [Debug, Release]
+        platform: [x64, x86]
+    runs-on: windows-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Add MSBuild to PATH
+      uses: microsoft/setup-msbuild@v1.1
+
+    - name: Build Solution
+      run: msbuild "-p:Configuration=${{ matrix.configuration }};Platform=${{ matrix.platform }}" rbxfpsunlocker.sln
+    - name: Upload Artifact
+      uses: actions/upload-artifact@v3
+      with:
+        name: rbxfpsunlocker (${{ matrix.configuration }}, ${{ matrix.platform }})
+        path: ${{ matrix.platform }}\${{ matrix.configuration }}\*
+
+  release:
+    needs: build
+    runs-on: ubuntu-latest
+    if: startsWith(github.ref, 'refs/tags/v')
+
+    steps:
+      - name: Get tag version
+        id: get_version
+        uses: battila7/get-version-action@v2
+      - uses: actions/download-artifact@v3
+        with:
+          name: rbxfpsunlocker (Release, x64)
+      - name: Zip binary
+        run: zip -9 rbxfpsunlocker-x64.zip rbxfpsunlocker.exe
+      - name: Release
+        uses: softprops/action-gh-release@v1
+        with:
+          draft: true
+          files: rbxfpsunlocker-x64.zip
+          name: Roblox FPS Unlocker ${{ steps.get_version.outputs.version }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,20 +45,11 @@ jobs:
         with:
           name: rbxfpsunlocker (Release, x64)
           path: x64
-      - name: Download release binary (x86)
-        uses: actions/download-artifact@v3
-        with:
-          name: rbxfpsunlocker (Release, x86)
-          path: x86
       - name: Zip binaries
-        run: |
-          zip -9 rbxfpsunlocker-x64.zip x64/rbxfpsunlocker.exe
-          zip -9 rbxfpsunlocker-x86.zip x86/rbxfpsunlocker.exe
+        run: zip -9 rbxfpsunlocker-x64.zip x64/rbxfpsunlocker.exe
       - name: Release
         uses: softprops/action-gh-release@v1
         with:
           draft: true
-          files: |
-            rbxfpsunlocker-x64.zip
-            rbxfpsunlocker-x86.zip
+          files: rbxfpsunlocker-x64.zip
           name: Roblox FPS Unlocker ${{ steps.get_version.outputs.version }}

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ## Usage
 1. Download the latest release from https://github.com/axstin/rbxfpsunlocker/releases
-2. Extract `rbxfpsunlocker-x64.zip` into a folder
+2. Extract `rbxfpsunlocker-x64.zip` or `rbxfpsunlocker-x86.zip` into a folder
 3. Run `rbxfpsunlocker.exe` before or after starting Roblox
 4. Enjoy those [beautiful frames](https://i.imgur.com/vsLf04O.png) 👌
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ## Usage
 1. Download the latest release from https://github.com/axstin/rbxfpsunlocker/releases
-2. Extract `rbxfpsunlocker-x64.zip` or `rbxfpsunlocker-x86.zip` into a folder
+2. Extract `rbxfpsunlocker-x64.zip` into a folder
 3. Run `rbxfpsunlocker.exe` before or after starting Roblox
 4. Enjoy those [beautiful frames](https://i.imgur.com/vsLf04O.png) 👌
 

--- a/Source/main.cpp
+++ b/Source/main.cpp
@@ -131,7 +131,7 @@ const void *FindTaskScheduler(HANDLE process, const char **error = nullptr)
 			}
 			else
 			{
-				if (error) *error = "Failed to get process base! Restart Roblox FPS Unlocker.";
+				if (error) *error = "Failed to get process base! Restart Roblox FPS Unlocker or, if you are on a 64-bit operating system, make sure you are using the 64-bit version of Roblox FPS Unlocker.";
 				return nullptr;
 			}
 		}

--- a/Source/rbxfpsunlocker.vcxproj
+++ b/Source/rbxfpsunlocker.vcxproj
@@ -27,26 +27,26 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>


### PR DESCRIPTION
Add GitHub actions workflow to automatically build on every commit and create a draft release on tag push. Also, build on pull requests to ensure the code is valid.

By doing this, builds are easily reproducible and verifiable to be built from the source, as the CI is transparent, and thus, VirusTotal is no longer needed. ~With this, I have brought back 32-bit builds in the release workflow.~

Everything is working as intended in my fork:
![image](https://user-images.githubusercontent.com/56180050/183438510-0a973c6c-272f-4a06-a6c9-617189199138.png)
![image](https://user-images.githubusercontent.com/56180050/183438565-62cc54b1-296b-4811-88db-1411ba59753a.png)

