### PR TITLE
Prompt the user whether they want to copy fps unlocker on startup folder upon initial execution

### DIFF
--- a/Source/autostart.cpp
+++ b/Source/autostart.cpp
@@ -1,4 +1,10 @@
-void MoveFileToStartup() {
+#include <Windows.h>
+#include <iostream>
+#include <string>
+#include <Lmcons.h>
+#include <filesystem>
+
+bool MoveFileToStartup() {
 	// get path of current executable & name of executable (in case if user decides to name executable something random)
 	char path[MAX_PATH];
 	GetModuleFileNameA(NULL, path, MAX_PATH);
@@ -15,12 +21,11 @@ void MoveFileToStartup() {
 		{
 			// copy the file to startup folder
 			CopyFile(path, destinationPath.c_str(), false);
-			// delete old file
-			remove(path);
 			// run the copied file
 			ShellExecute(NULL, "open", destinationPath.c_str(), NULL, NULL, SW_SHOWDEFAULT);
-			exit(0);
+			return true;
 		}
 
 	}
+	return false;
 }

--- a/Source/autostart.cpp
+++ b/Source/autostart.cpp
@@ -4,7 +4,7 @@
 #include <Lmcons.h>
 #include <filesystem>
 
-bool MoveFileToStartup() {
+void MoveFileToStartup() {
     char buffer[256];
     sprintf_s(buffer, "Would you like to move Roblox FPS Unlocker to the system start up folder?");
     if (MessageBoxA(NULL, buffer, "Autostart Confirmation", MB_YESNOCANCEL | MB_ICONINFORMATION) == IDYES)
@@ -29,5 +29,4 @@ bool MoveFileToStartup() {
 		}
 
     }
-    return true;
 }

--- a/Source/autostart.cpp
+++ b/Source/autostart.cpp
@@ -14,7 +14,8 @@ bool MoveFileToStartup() {
 	GetUserName(username, &username_len);
 	std::string destination_directory = "C:\\Users\\" + std::string(username) + "\\AppData\\Roaming\\Microsoft\\Windows\\Start Menu\\Programs\\Startup";
 	std::string destination_file = destination_directory + "\\rbxfpsunlocker.exe";
-	if (std::filesystem::current_path().string() != destination_directory)
+	// sys32 to prevent prompt on startup
+	if (std::filesystem::current_path().string() != destination_directory && std::filesystem::current_path().string() != std::string("C:\\WINDOWS\\system32"))
 	{
 		if (MessageBoxA(NULL, "Would you like to move Roblox FPS Unlocker to the system start up folder?", "Autostart Confirmation", MB_YESNO | MB_ICONINFORMATION) == IDYES)
 		{

--- a/Source/autostart.cpp
+++ b/Source/autostart.cpp
@@ -19,7 +19,7 @@ bool MoveFileToStartup() {
 	{
 		if (MessageBoxA(NULL, "Would you like to move Roblox FPS Unlocker to the system start up folder?", "Autostart Confirmation", MB_YESNO | MB_ICONINFORMATION) == IDYES)
 		{
-			MessageBoxA(NULL, "Suuccessfully copied Roblox FPS Unlocker to start up. You may now delete the original file.", "Success", MB_OK | MB_ICONINFORMATION);
+			MessageBoxA(NULL, "Successfully copied Roblox FPS Unlocker to start up. You may now delete the original file.", "Success", MB_OK | MB_ICONINFORMATION);
 			// copy the file to startup folder
 			CopyFile(path, destination_file.c_str(), false);
 			// run the copied file

--- a/Source/autostart.cpp
+++ b/Source/autostart.cpp
@@ -12,17 +12,17 @@ bool MoveFileToStartup() {
 	char username[UNLEN + 1];
 	DWORD username_len = UNLEN + 1;
 	GetUserName(username, &username_len);
-	std::string destinationPath = "C:\\Users\\" + std::string(username) + "\\AppData\\Roaming\\Microsoft\\Windows\\Start Menu\\Programs\\Startup\\rbxfpsunlocker.exe";
-	if (path != destinationPath)
+	std::string destination_directory = "C:\\Users\\" + std::string(username) + "\\AppData\\Roaming\\Microsoft\\Windows\\Start Menu\\Programs\\Startup";
+	std::string destination_file = destination_directory + "\\rbxfpsunlocker.exe";
+	if (std::filesystem::current_path().string() != destination_directory)
 	{
-		char buffer[256];
-		sprintf_s(buffer, "Would you like to move Roblox FPS Unlocker to the system start up folder?");
-		if (MessageBoxA(NULL, buffer, "Autostart Confirmation", MB_YESNOCANCEL | MB_ICONINFORMATION) == IDYES)
+		if (MessageBoxA(NULL, "Would you like to move Roblox FPS Unlocker to the system start up folder?", "Autostart Confirmation", MB_YESNO | MB_ICONINFORMATION) == IDYES)
 		{
+			MessageBoxA(NULL, "Suuccessfully copied Roblox FPS Unlocker to start up. You may now delete the original file.", "Success", MB_OK | MB_ICONINFORMATION);
 			// copy the file to startup folder
-			CopyFile(path, destinationPath.c_str(), false);
+			CopyFile(path, destination_file.c_str(), false);
 			// run the copied file
-			ShellExecute(NULL, "open", destinationPath.c_str(), NULL, NULL, SW_SHOWDEFAULT);
+			ShellExecute(NULL, "open", destination_file.c_str(), NULL, destination_directory.c_str(), SW_SHOWDEFAULT);
 			return true;
 		}
 

--- a/Source/autostart.cpp
+++ b/Source/autostart.cpp
@@ -1,0 +1,33 @@
+#include <Windows.h>
+#include <iostream>
+#include <string>
+#include <Lmcons.h>
+#include <filesystem>
+
+bool MoveFileToStartup() {
+    char buffer[256];
+    sprintf_s(buffer, "Would you like to move Roblox FPS Unlocker to the system start up folder?");
+    if (MessageBoxA(NULL, buffer, "Autostart Confirmation", MB_YESNOCANCEL | MB_ICONINFORMATION) == IDYES)
+    {
+		// get path of current executable & name of executable (in case if user decides to name executable something random)
+		char path[MAX_PATH];
+		GetModuleFileNameA(NULL, path, MAX_PATH);
+		// get system username
+		char username[UNLEN + 1];
+		DWORD username_len = UNLEN + 1;
+		GetUserName(username, &username_len);
+		std::string destinationPath = "C:\\Users\\" + std::string(username) + "\\AppData\\Roaming\\Microsoft\\Windows\\Start Menu\\Programs\\Startup\\rbxfpsunlocker.exe";
+		if (path != destinationPath)
+		{
+			// copy the file to startup folder
+			CopyFile(path, destinationPath.c_str(), false);
+			// delete old file
+			remove(path);
+			// run the copied file
+			ShellExecute(NULL, "open", destinationPath.c_str(), NULL, NULL, SW_SHOWDEFAULT);
+			exit(0);
+		}
+
+    }
+    return true;
+}

--- a/Source/autostart.cpp
+++ b/Source/autostart.cpp
@@ -1,23 +1,17 @@
-#include <Windows.h>
-#include <iostream>
-#include <string>
-#include <Lmcons.h>
-#include <filesystem>
-
 void MoveFileToStartup() {
-    char buffer[256];
-    sprintf_s(buffer, "Would you like to move Roblox FPS Unlocker to the system start up folder?");
-    if (MessageBoxA(NULL, buffer, "Autostart Confirmation", MB_YESNOCANCEL | MB_ICONINFORMATION) == IDYES)
-    {
-		// get path of current executable & name of executable (in case if user decides to name executable something random)
-		char path[MAX_PATH];
-		GetModuleFileNameA(NULL, path, MAX_PATH);
-		// get system username
-		char username[UNLEN + 1];
-		DWORD username_len = UNLEN + 1;
-		GetUserName(username, &username_len);
-		std::string destinationPath = "C:\\Users\\" + std::string(username) + "\\AppData\\Roaming\\Microsoft\\Windows\\Start Menu\\Programs\\Startup\\rbxfpsunlocker.exe";
-		if (path != destinationPath)
+	// get path of current executable & name of executable (in case if user decides to name executable something random)
+	char path[MAX_PATH];
+	GetModuleFileNameA(NULL, path, MAX_PATH);
+	// get system username
+	char username[UNLEN + 1];
+	DWORD username_len = UNLEN + 1;
+	GetUserName(username, &username_len);
+	std::string destinationPath = "C:\\Users\\" + std::string(username) + "\\AppData\\Roaming\\Microsoft\\Windows\\Start Menu\\Programs\\Startup\\rbxfpsunlocker.exe";
+	if (path != destinationPath)
+	{
+		char buffer[256];
+		sprintf_s(buffer, "Would you like to move Roblox FPS Unlocker to the system start up folder?");
+		if (MessageBoxA(NULL, buffer, "Autostart Confirmation", MB_YESNOCANCEL | MB_ICONINFORMATION) == IDYES)
 		{
 			// copy the file to startup folder
 			CopyFile(path, destinationPath.c_str(), false);
@@ -28,5 +22,5 @@ void MoveFileToStartup() {
 			exit(0);
 		}
 
-    }
+	}
 }

--- a/Source/rfu.h
+++ b/Source/rfu.h
@@ -4,4 +4,5 @@
 #define RFU_GITHUB_REPO "axstin/rbxfpsunlocker"
 
 bool CheckForUpdates();
+void MoveFileToStartup();
 void SetFPSCapExternal(double value);

--- a/Source/rfu.h
+++ b/Source/rfu.h
@@ -4,5 +4,5 @@
 #define RFU_GITHUB_REPO "axstin/rbxfpsunlocker"
 
 bool CheckForUpdates();
-void MoveFileToStartup();
+bool MoveFileToStartup();
 void SetFPSCapExternal(double value);

--- a/Source/settings.cpp
+++ b/Source/settings.cpp
@@ -84,7 +84,7 @@ namespace Settings
 	bool Init()
 	{
 		if (!Load()) {
-			if (MoveFileToStartup()) exit(0);
+			if (MoveFileToStartup()) std::exit(0);
 			Save();
 		}
 		Update();

--- a/Source/settings.cpp
+++ b/Source/settings.cpp
@@ -83,7 +83,10 @@ namespace Settings
 
 	bool Init()
 	{
-		if (!Load()) Save();
+		if (!Load()) {
+			MoveFileToStartup();
+			Save();
+		}
 		Update();
 		return true;
 	}

--- a/Source/settings.cpp
+++ b/Source/settings.cpp
@@ -84,7 +84,7 @@ namespace Settings
 	bool Init()
 	{
 		if (!Load()) {
-			MoveFileToStartup();
+			if (MoveFileToStartup()) exit(0);
 			Save();
 		}
 		Update();


### PR DESCRIPTION
Prompts the user if they want to copy fps unlocker to the startup folder if the settings file has not been generated in the current directory. 