### PR TITLE
Bump actions/checkout to 3.3.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: windows-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v3.3.0
     - name: Add MSBuild to PATH
       uses: microsoft/setup-msbuild@v1.3
 


### PR DESCRIPTION
Actually, 3.3.0 can be 3.3 but I think it's 3.3.0.