### PR TITLE
fix crashes

### DIFF
--- a/Source/main.cpp
+++ b/Source/main.cpp
@@ -312,7 +312,7 @@ class RobloxProcess
 
 	bool BlockingLoadModuleInfo()
 	{
-		int tries = 5;
+		int tries = 6;
 		int wait_time = 100;
 
 		printf("[%u] Finding process base...\n", process.id);

--- a/Source/procutil.cpp
+++ b/Source/procutil.cpp
@@ -65,7 +65,14 @@ std::vector<ProcUtil::ModuleInfo> ProcUtil::GetProcessModules(DWORD process_id, 
 
 	HANDLE snapshot = CreateToolhelp32Snapshot(TH32CS_SNAPMODULE | TH32CS_SNAPMODULE32, process_id);
 	if (snapshot == INVALID_HANDLE_VALUE)
-		throw WindowsException("unable to enum modules");
+	{
+		DWORD error_code = GetLastError();
+
+		printf("[%u] Could not create snapshot! Error code: %lu\n",
+			process_id,
+			error_code
+		);
+	}
 
 	if (Module32FirstW(snapshot, &entry) == TRUE)
 	{


### PR DESCRIPTION
CreateToolhelp32Snapshot may occasionally fail and cause error 299 (Only part of a ReadProcessMemory or WriteProcessMemory request was completed) which causes an exception, however after some time the function won't fail anymore.

this is a simple fix that works thanks to the retry system in BlockingLoadModuleInfo()

on my side, to reproduce the bug you need to go on Studio and start a 2 player server, and this could happen on the roblox player too but it's somewhat rare